### PR TITLE
New binary seems to be compiled for 64 bit resulting in a libc error.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt update -y && \
-  apt install -y gdb curl lib32gcc1 && \
+  apt install -y gdb curl libc++-dev lib32gcc1 && \
   rm -rf /var/lib/apt/lists/*
 RUN useradd -m steam
 WORKDIR /home/steam/Steam


### PR DESCRIPTION
Current docker image updates but results in:

error while loading shared libraries: libc++.so.1: cannot open shared object file: No such file or directory

This fixes it. I created a working image that I swapped in. You can find that here: https://hub.docker.com/repository/docker/ramoneelman/pavlovdocker-clone-from-ihadeed